### PR TITLE
Remove redundant foldable node alist

### DIFF
--- a/ts-fold-indicators.el
+++ b/ts-fold-indicators.el
@@ -267,8 +267,8 @@ Argument FOLDED holds folding state; it's a boolean."
   (when ts-fold-indicators-mode
     (ts-fold--ensure-ts
       (when-let* ((node (tsc-root-node tree-sitter-tree))
-                  (patterns (seq-mapcat (lambda (type) `(,(list type) @name))
-                                        (alist-get major-mode ts-fold-foldable-node-alist)
+                  (patterns (seq-mapcat (lambda (fold-range) `((,(car fold-range)) @name))
+                                        (alist-get major-mode ts-fold-range-alist)
                                         'vector))
                   (query (ignore-errors
                            (tsc-make-query tree-sitter-language patterns)))

--- a/ts-fold-summary.el
+++ b/ts-fold-summary.el
@@ -229,7 +229,7 @@ type of content by checking the word boundary's existence."
     (typescript-mode   . ts-fold-summary-javadoc)
     (nxml-mode         . ts-fold-summary-xml))
   "Alist mapping `major-mode' to doc parser function."
-  :type 'hook
+  :type '(alist :key-type symbol :value-type function)
   :group 'ts-fold)
 
 (provide 'ts-fold-summary)


### PR DESCRIPTION
As discussed in [issue 35](https://github.com/emacs-tree-sitter/ts-fold/issues/35) the fact that the foldable nodes are defined in two data structures makes ts-fold much harder to configure inside of configs. In this commit I've moved everything to use the `ts-fold-range-alist` and was able to cut away other pieces of code in the process. Now people can handle their ts fold definitions like they would with any other alist!

I have also removed the user error that gets emitted when there is no foldable node since I personally was finding the extra noise quite annoying and the operation is valid. Other folding packages don't provide such errors when a fold is requested but none is made.

Since this is removing a piece of code that seems to provide some searching shortcuts, I performed some rudimentary benchmarks with to to make sure that the change wouldn't be greatly detrimental to performance. The results showed no noticeable degradation to performance:
```elisp
(benchmark 300 (ts-fold-toggle))

Elapsed time: 1.604777s (0.759565s in 5 GCs) <- Original code
Elapsed time: 1.580959s (0.763199s in 5 GCs) <- This change
```
when running this, I found the code from this PR was slightly faster in the end. Since I do use compiled packages, I made sure to run each test with each version of ts-fold compiled first.

Let me know if you have any other questions! it was a lot of fun to work on this so I hope it turns out to be helpful to others as well!