### PR TITLE
Change global mode to turn on with tree-sitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,27 @@ or
 
 The following are the functions provided by `ts-fold-mode`
 
-| Commands                   | Description                                                                 |
-| -------------------------- | --------------------------------------------------------------------------- |
-| `ts-fold-close`            | fold the current syntax node.                                               |
-| `ts-fold-open`             | open all folds inside the current syntax node.                              |
-| `ts-fold-open-recursively` | open the outmost fold of the current syntax node. Keep the sub-folds close. |
-| `ts-fold-close-all`        | close all foldable syntax nodes in the current buffer.                      |
-| `ts-fold-open-all`         | open all folded syntax nodes in the current buffer.                         |
-| `ts-fold-toggle`           | toggle the syntax node at `point'.                                          |
+Commands for enabling `ts-fold`:
+
+| Commands                         | Description                                                                                         |
+| -------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `ts-fold-mode`                   | enable `ts-fold-mode` in the current buffer.                                                        |
+| `global-ts-fold-mode`            | enable `ts-fold-mode` whenever tree-sitter is turned on and the major mode is supported by ts-fold. |
+| `ts-fold-indicators-mode`        | enable ts-fold with indicators in the current buffer. See [plugins section](#-indicators-mode).     |
+| `global-ts-fold-indicators-mode` | enable ts-fold with indicators globally. See [plugins section](#-indicators-mode).                  |
+
+Commands for using `ts-fold`.
+
+| Commands                   | Description                                                                   |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `ts-fold-close`            | fold the current syntax node.                                                 |
+| `ts-fold-open`             | open the outermost fold of the current syntax node. Keep the sub-folds close. |
+| `ts-fold-open-recursively` | open all folds inside the current syntax node.                                |
+| `ts-fold-close-all`        | close all foldable syntax nodes in the current buffer.                        |
+| `ts-fold-open-all`         | open all folded syntax nodes in the current buffer.                           |
+| `ts-fold-toggle`           | toggle the syntax node at `point'.                                            |
+
+If evil mode is loaded, then these commands are also added to the evil folding list.
 
 ### 🔨 Supported languages
 
@@ -340,7 +353,7 @@ basic `ts-fold-range-seq`.
 ts-fold comes with a couple of useful little additions that can be used or
 turned off as desired.
 
-### ⚖️ Indicators Mode
+### ⚖ Indicators Mode
 
 <p align="center">
 <img src="./etc/indicators.png" width="40%" height=480%"/>
@@ -376,19 +389,28 @@ explicitly declare the package in in your config.
 
 #### 🖥 Usage
 
-You can then enable this manually by doing the following
+You can then enable this manually by doing either of the following:
 
 ```
 M-x ts-fold-indicators-mode
+
+M-x global-ts-fold-indicators-mode
 ```
 
 Please note that turning on `ts-fold-indicators-mode` automatically turns on
-`ts-fold-mode` as well.
+`ts-fold-mode` as well. Though, turning off `ts-fold-indicators-mode` does not
+turn off `ts-fold-mode`
 
-- To enable this automatically whenever `tree-sitter-mode` is enabled:
+- To enable this automatically whenever `tree-sitter-mode` is enabled, use the global indicator mode:
 
   ```elisp
-  (add-hook 'tree-sitter-after-on-hook #ts-fold-indicators-mode)
+  (global-ts-fold-indicators-mode 1)
+  ```
+
+  Else, a hook can be added to tree-sitter directly.
+
+  ```elisp
+  (add-hook 'tree-sitter-after-on-hook #'ts-fold-indictors-mode)
   ```
 
 - To switch to left/right fringe: (Default is `left-fringe`)

--- a/ts-fold-indicators.el
+++ b/ts-fold-indicators.el
@@ -106,7 +106,7 @@
 
 (defun ts-fold-indicators--enable ()
   "Enable `ts-fold-indicators' mode."
-  (if (ts-fold-mode 1)  ; Enable `ts-fold-mode' automatically
+  (if (or ts-fold-mode (ts-fold-mode 1))  ; Enable `ts-fold-mode' automatically
       (progn
         (add-hook 'tree-sitter-after-change-functions #'ts-fold-indicators-refresh nil t)
         (add-hook 'after-save-hook #'ts-fold-indicators-refresh nil t)
@@ -130,8 +130,20 @@
     (ts-fold-indicators--disable)))
 
 ;;;###autoload
-(define-global-minor-mode global-ts-fold-indicators-mode ts-fold-indicators-mode
-  (lambda () (ts-fold-indicators-mode 1)))
+(define-minor-mode global-ts-fold-indicators-mode
+  "Global minor mode for turning on ts-fold with indicators whenever avaliable."
+  :group 'ts-fold
+  :lighter nil
+  :init-value nil
+  :global t
+  (if global-ts-fold-indicators-mode
+      (progn
+        (add-hook 'ts-fold-mode-hook #'ts-fold-indicators-mode)
+        (global-ts-fold-mode 1)
+        (dolist (buf (buffer-list))
+          (with-current-buffer buf
+            (when (and ts-fold-mode (not ts-fold-indicators-mode) (ts-fold-indicators-mode))))))
+    (remove-hook 'ts-fold-mode-hook #'ts-fold-indicators-mode)))
 
 ;;
 ;; (@* "Events" )

--- a/ts-fold.el
+++ b/ts-fold.el
@@ -144,9 +144,7 @@ the fold in a cons cell.  See `ts-fold-range-python' for an example."
                    :close ts-fold-close
                    :open-rec ts-fold-open-recursively
                    :open-all ts-fold-open-all
-                   :close-all ts-fold-close-all)))
-
-  (run-hooks 'ts-fold-mode-hook))
+                   :close-all ts-fold-close-all))))
 
 (defun ts-fold--disable ()
   "Stop folding minor mode."
@@ -154,16 +152,41 @@ the fold in a cons cell.  See `ts-fold-range-python' for an example."
   (let ((tree-sitter-mode t))
     (ts-fold-open-all)))
 
+(defun ts-fold--tree-sitter-trigger ()
+  "Turn `ts-fold-mode' on and off alongside `tree-sitter-mode'
+when in a mode ts-fold can act on."
+  (if (and tree-sitter-mode (ts-fold-usable-mode-p))
+      (ts-fold-mode 1)
+    (ts-fold-mode -1)))
+
 ;;;###autoload
 (define-minor-mode ts-fold-mode
   "Folding code using tree sitter."
+  :group 'ts-fold
   :init-value nil
   :lighter "TS-Fold"
   (if ts-fold-mode (ts-fold--enable) (ts-fold--disable)))
 
 ;;;###autoload
-(define-global-minor-mode global-ts-fold-mode ts-fold-mode
-  (lambda () (ts-fold-mode 1)))
+(define-minor-mode global-ts-fold-mode
+  "Use `ts-fold-mode' wherever possible"
+  :group 'ts-fold
+  :init-value nil
+  :lighter nil
+  :global t
+  (if global-ts-fold-mode
+      (progn
+        (add-hook 'tree-sitter-mode-hook #'ts-fold--tree-sitter-trigger)
+        ;; try to turn on in all buffers.
+        (dolist (buf (buffer-list))
+          (with-current-buffer buf
+            (ts-fold--tree-sitter-trigger))))
+    (remove-hook 'tree-sitter-mode-hook #'ts-fold--tree-sitter-trigger)))
+
+(defun ts-fold-usable-mode-p (&optional mode)
+  "Return non-nil if `ts-fold' has defined folds for MODE."
+  (let ((mode (or mode major-mode)))
+    (alist-get mode ts-fold-range-alist)))
 
 ;;
 ;; (@* "Core" )


### PR DESCRIPTION
The global mode that is currently defined has the issue that it turns on in all buffers which can cause issues with smart folding patterns. By linking the major mode to `tree-sitter`, ts-fold will only turn on when it's in a file where it will actually work.

This is meant to fix the issue brought up in [issue 3](https://github.com/emacs-tree-sitter/ts-fold/issues/3) where ts-fold doesn't do a good job of respecting evil's folding pattern. Unlike other folding packages such as origami mode, ts-fold doesn't have any defaults to fall back to when tree-sitter isn't enabled or even if there just aren't any folds defined for the current major mode. To fix this, I'm redefining the major mode to only add a hook to tree-sitter instead of turning ts-fold on everywhere. I've also added a check to make sure the current major mode has at least some syntax folding defined within ts-fold so that it doesn't activate itself when it can't be used.