### PR TITLE
Add extra folding definitions for golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,30 @@ For the folding functions, ts-fold provides some default
   int main() {...} // Folded node
   ```
 
+- `ts-fold-range-markers` - Folds the node starting from a giving delimiter
+  character. Useful if tree-sitter's node definition doesn't align with the
+  start of the desired folding section.
+
+  **NOTE:** This folding function requires a lambda (or an externally
+  defined function wrapper) so that the delimiter can be specified. You
+  usually don't need to worry about the `node` and `offset` variables, so just
+  pass them through.
+
+```go
+type Dog interface {
+    Bark() (string, error)
+    Beg() (bool, error)
+}
+
+/* | Note: The tree-sitter node starts at the word interface, not at the '{'.
+ * | '(interface_type . (lambda (node offset)
+ * |                      (ts-fold-range-markers node offset "{" "}")))
+ * V
+ */
+
+type Dog interface {...}
+```
+
 - `ts-fold-range-block-comment` - Folds multi-line comments that are of the form
   `/*...*/`. Should show a summary if the commentary plugin is turned on.
 
@@ -213,8 +237,10 @@ For the folding functions, ts-fold provides some default
 
 - `ts-fold-range-line-comment` - For languages that have one line comment blocks
   with the comment delimiter starting each line. Condenses all the comment nodes
-  into a single fold. This folding function requires a lambda (or an externally
-  defined function wrapper) so that the comment delimiter can be specified. You
+  into a single fold.
+
+  **Note:** This folding function requires a lambda (or an externally
+  defined function wrapper) so that the delimiter can be specified. You
   usually don't need to worry about the `node` and `offset` variables, so just
   pass them through.
 
@@ -499,7 +525,7 @@ As can be seen `ts-fold-summary--generic` is a very helpful function since it
 removes the provided delimiter and returns the first line. often this will be
 enough.
 
-### 🌫️ Line-Comment folding
+### 🌫 Line-Comment folding
 
 <p align="center">
 <img src="./etc/line-comment.gif" width="80%" height="80%"/>

--- a/ts-fold-parsers.el
+++ b/ts-fold-parsers.el
@@ -122,8 +122,14 @@
 
 (defun ts-fold-parsers-go ()
   "Rule set for Go."
-  '((block   . ts-fold-range-seq)
-    (comment . ts-fold-range-seq)))
+  '((block                  . ts-fold-range-seq)
+    (comment                . ts-fold-range-seq)
+    (const_declaration      . (lambda (node offset)
+                                (ts-fold-range-markers node offset "(" ")")))
+    (field_declaration_list . ts-fold-range-seq)
+    (import_spec_list       . ts-fold-range-seq)
+    (interface_type         . (lambda (node offset)
+                                (ts-fold-range-markers node offset "{" "}")))))
 
 (defun ts-fold-parsers-html ()
   "Rule set for HTML."

--- a/ts-fold-util.el
+++ b/ts-fold-util.el
@@ -26,14 +26,6 @@
 ;;; Code:
 
 ;;
-;; (@* "Util" )
-;;
-
-(defun ts-fold-2-str (object)
-  "Convert OBJECT to string."
-  (format "%s" object))
-
-;;
 ;; (@* "Cons" )
 ;;
 
@@ -100,30 +92,33 @@ Optional argument TRIM, see function `ts-fold--get-face'."
 
 (defun ts-fold--compare-type (node type)
   "Compare NODE's type to TYPE."
-  (string= (ts-fold-2-str (tsc-node-type node)) type))
+  ;; tsc-node-type returns a symbol or a string and `string=' automatically
+  ;; converts symbols to strings
+  (string= (tsc-node-type node) type))
 
-(defun ts-fold-children (node)
-  "Return children from NODE."
+(defun ts-fold-get-children (node)
+  "Get list of direct children of NODE."
   (let (children)
     (dotimes (index (tsc-count-children node))
       (push (tsc-get-nth-child node index) children))
     (reverse children)))
 
-(defun ts-fold-children-traverse (node)
+(defun ts-fold-get-children-traverse (node)
   "Return children from NODE but traverse it."
   (let (nodes)
-    (tsc-traverse-mapc (lambda (next) (push next nodes)) node)
+    (tsc-traverse-mapc (lambda (child) (push child nodes)) node)
     (reverse nodes)))
 
 (defun ts-fold-find-children (node type)
-  "Search node TYPE from children; this return a list."
-  (cl-remove-if-not (lambda (next) (ts-fold--compare-type next type))
-                    (ts-fold-children node)))
+  "Search through the children of NODE to find all with type equal to TYPE;
+then return that list."
+  (cl-remove-if-not (lambda (child) (ts-fold--compare-type child type))
+                    (ts-fold-get-children node)))
 
 (defun ts-fold-find-children-traverse (node type)
   "Like function `ts-fold-find-children' but traverse it."
-  (cl-remove-if-not (lambda (next) (ts-fold--compare-type next type))
-                    (ts-fold-children-traverse node)))
+  (cl-remove-if-not (lambda (child) (ts-fold--compare-type child type))
+                    (ts-fold-get-children-traverse node)))
 
 (defun ts-fold-find-parent (node type)
   "Find the TYPE of parent from NODE."

--- a/ts-fold.el
+++ b/ts-fold.el
@@ -401,6 +401,26 @@ Argument OFFSET can be used to tweak the final beginning and end position."
         (end (1- (tsc-node-end-position node))))
     (ts-fold--cons-add (cons beg end) offset)))
 
+(defun ts-fold-range-markers (node offset start-seq &optional end-seq)
+  "Returns the fold range for NODE with an OFFSET where the range starts at
+the end of the first occurence of START-SEQ and ends at the end of the node
+or the start of the last occurence of the optional parameter LAST-SEQ.
+
+START-SEQ and LAST-SEQ can be named tree-sitter nodes or anonomous nodes.
+
+If no occurence is found for START-SEQ or END-SEQ or the
+occurences overlap, then the range returned is nil."
+  (when start-seq
+    (when-let ((beg-node (car (ts-fold-find-children node start-seq)))
+               (end-node (if end-seq
+                             (car (last (ts-fold-find-children node end-seq)))
+                           node))
+               (beg (tsc-node-end-position beg-node))
+               (end (if end-seq
+                        (tsc-node-start-position end-node)
+                      (1- (tsc-node-end-position node)))))
+      (unless (> beg end) (ts-fold--cons-add (cons beg end) offset)))))
+
 (defun ts-fold-range-line-comment (node offset prefix)
   "Define fold range for line comment.
 


### PR DESCRIPTION
This PR adds a couple of folding I personally have found quite useful as defaults for working with golang. Figured I'd add them to the general defaults so others can enjoy a better experience out of the box.

### field_declaration_list
```go
type point struct {
    x int
    y int
}

/* |
 * V
 */

type point struct {...}
```

### import_spec_list
```go
import (
    "fmt"
    "time"
)

/* |
 * V
 */

import (...)
```

### interface_type
Needs to be offset quite a bit since the tree-sitter definition includes the word **interface** which should still be shown.
```go
type Dog interface {
    Bark() (string, error)
    Beg() (bool, error)
}

/* |
 * V
 */

type Dog interface {...}
```