### PR TITLE
Optimize performance of ts-fold-close-all with indicators-mode on

### DIFF
--- a/ts-fold.el
+++ b/ts-fold.el
@@ -323,9 +323,9 @@ If the current node is not folded or not foldable, do nothing."
 (defun ts-fold-close-all ()
   "Fold all foldable syntax nodes in the buffer."
   (interactive)
-  (advice-remove #'ts-fold-close #'ts-fold--after-command)
   (ts-fold--ensure-ts
-    (let* ((node (tsc-root-node tree-sitter-tree))
+    (let* ((ts-fold-indicators-mode)
+           (node (tsc-root-node tree-sitter-tree))
            (patterns (seq-mapcat (lambda (fold-range) `((,(car fold-range)) @name))
                                  (alist-get major-mode ts-fold-range-alist)
                                  'vector))
@@ -333,9 +333,7 @@ If the current node is not folded or not foldable, do nothing."
            (nodes-to-fold (tsc-query-captures query node #'ignore)))
       (thread-last nodes-to-fold
                    (mapcar #'cdr)
-                   (mapc #'ts-fold-close))))
-  (advice-add #'ts-fold-close :after #'ts-fold--after-command)
-  )
+                   (mapc #'ts-fold-close)))))
 
 ;;;###autoload
 (defun ts-fold-open-all ()

--- a/ts-fold.el
+++ b/ts-fold.el
@@ -323,6 +323,7 @@ If the current node is not folded or not foldable, do nothing."
 (defun ts-fold-close-all ()
   "Fold all foldable syntax nodes in the buffer."
   (interactive)
+  (advice-remove #'ts-fold-close #'ts-fold--after-command)
   (ts-fold--ensure-ts
     (let* ((node (tsc-root-node tree-sitter-tree))
            (patterns (seq-mapcat (lambda (fold-range) `((,(car fold-range)) @name))
@@ -332,7 +333,9 @@ If the current node is not folded or not foldable, do nothing."
            (nodes-to-fold (tsc-query-captures query node #'ignore)))
       (thread-last nodes-to-fold
                    (mapcar #'cdr)
-                   (mapc #'ts-fold-close)))))
+                   (mapc #'ts-fold-close))))
+  (advice-add #'ts-fold-close :after #'ts-fold--after-command)
+  )
 
 ;;;###autoload
 (defun ts-fold-open-all ()


### PR DESCRIPTION
Since ts-fold-close-all and ts-fold-close are both advised, ts-fold-indicators-refresh will be called every time ts-fold-close-all calls ts-fold-close on target nodes. Then ts-fold-close-all is far from being responsive with indicators-mode on.
So we just remove the advice before we call ts-fold-close in ts-fold-close-all, and get it back before we leave. Of course, ts-fold-indicators-refresh will be called as an advice of ts-fold-close-all which we didn't modify.

On my laptop, it took more than 3 seconds to collapse all. With the patch, it's just in a flash now.