### PR TITLE
Fix for ts-fold not checking if tree-sitter is enabled

### DIFF
--- a/ts-fold-indicators.el
+++ b/ts-fold-indicators.el
@@ -276,7 +276,7 @@ Argument FOLDED holds folding state; it's a boolean."
 ;;;###autoload
 (defun ts-fold-indicators-refresh (&rest _)
   "Refresh indicators for all folding range."
-  (when ts-fold-indicators-mode
+  (when (and tree-sitter-mode ts-fold-indicators-mode)
     (ts-fold--ensure-ts
       (when-let* ((node (ignore-errors (tsc-root-node tree-sitter-tree)))
                   (patterns (seq-mapcat (lambda (fold-range) `((,(car fold-range)) @name))


### PR DESCRIPTION
If you enable tree-sitter then disable it, ts-fold is not disabled and this function will fail.