### PR TITLE
feature(parser): Add support for python docstring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +22,17 @@ jobs:
         emacs-version:
           - 27.2
           - 28.2
-          - snapshot
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: macos-latest
+            emacs-version: snapshot
+            experimental: true
+          - os: windows-latest
+            emacs-version: snapshot
+            experimental: true
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 * Improve folding for C preprocessor operators (#46)
 * Add more folding definitions (#51)
 * Add support for Lua (#52)
+* Add support for Python docstring (#58)
 
 ## 0.1.0
 > Released Oct 18, 2021

--- a/ts-fold-parsers.el
+++ b/ts-fold-parsers.el
@@ -225,10 +225,11 @@
 
 (defun ts-fold-parsers-python ()
   "Rule set for Python."
-  '((function_definition . ts-fold-range-python)
-    (class_definition    . ts-fold-range-python)
-    (list                . ts-fold-range-seq)
-    (dictionary          . ts-fold-range-seq)
+  '((function_definition  . ts-fold-range-python)
+    (class_definition     . ts-fold-range-python)
+    (list                 . ts-fold-range-seq)
+    (dictionary           . ts-fold-range-seq)
+    (expression_statement . ts-fold-range-python-expression-statement)
     (comment
      . (lambda (node offset)
          (ts-fold-range-line-comment node offset "#")))))

--- a/ts-fold.el
+++ b/ts-fold.el
@@ -616,6 +616,17 @@ more information."
               (end (tsc-node-end-position node)))
     (ts-fold--cons-add (cons beg end) offset)))
 
+(defun ts-fold-range-python-expression-statement (node offset)
+  "Define fold range for `expression_statement'.
+
+For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
+more information."
+  (when-let* ((string-node (car (ts-docstr-find-children node "string")))
+              ;; the colon is an anonymous node after return_type or parameters node
+              (beg (tsc-node-start-position string-node))
+              (end (tsc-node-end-position node)))
+    (ts-fold--cons-add (cons (+ beg 3) (- end 3)) offset)))
+
 (defun ts-fold-range-ruby-class-def (node offset)
   "Define fold range for `method' and `class' in Ruby.
 


### PR DESCRIPTION
Fold python docstring expression:

```py
def foo():
    """Test docstring
    """

# |
# |
# v

def foo():
    """..."""

```